### PR TITLE
Fix all dead links in navigation and content

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -111,17 +111,13 @@ export default defineConfig({
         {
           text: 'Market Analysis',
           items: [
-            { text: 'Overview', link: '/insights/market-analysis/' },
-            { text: 'Weekly Reports', link: '/insights/market-analysis/weekly' },
-            { text: 'Technical Analysis', link: '/insights/market-analysis/technical' }
+            { text: 'Overview', link: '/insights/market-analysis/' }
           ]
         },
         {
           text: 'Trading Strategies',
           items: [
-            { text: 'Overview', link: '/insights/trading-strategies/' },
-            { text: 'Beginner Strategies', link: '/insights/trading-strategies/beginner' },
-            { text: 'Advanced Strategies', link: '/insights/trading-strategies/advanced' }
+            { text: 'Overview', link: '/insights/trading-strategies/' }
           ]
         }
       ],
@@ -141,16 +137,13 @@ export default defineConfig({
           items: [
             { text: 'What is Contract Trading?', link: '/basics/what-is-contract-trading' },
             { text: 'Types of Contracts', link: '/basics/contract-types' },
-            { text: 'Leverage and Margin', link: '/basics/leverage-and-margin' },
-            { text: 'Key Terminology', link: '/basics/terminology' }
+            { text: 'Leverage and Margin', link: '/basics/leverage-and-margin' }
           ]
         },
         {
           text: 'Platform Basics',
           items: [
-            { text: 'Choosing a Platform', link: '/basics/choosing-platform' },
-            { text: 'Account Setup', link: '/basics/account-setup' },
-            { text: 'Interface Overview', link: '/basics/interface' }
+            { text: 'Choosing a Platform', link: '/basics/choosing-platform' }
           ]
         }
       ],
@@ -164,22 +157,12 @@ export default defineConfig({
             { text: 'Risk-Reward Ratio', link: '/risk-management/risk-reward' }
           ]
         },
-        {
-          text: 'Advanced Risk Control',
-          items: [
-            { text: 'Portfolio Diversification', link: '/risk-management/diversification' },
-            { text: 'Hedging Strategies', link: '/risk-management/hedging' },
-            { text: 'Market Risk Assessment', link: '/risk-management/market-risk' }
-          ]
-        }
       ],
       '/advanced-strategies/': [
         {
           text: 'Trading Strategies',
           items: [
-            { text: 'Scalping', link: '/advanced-strategies/scalping' },
-            { text: 'Swing Trading', link: '/advanced-strategies/swing-trading' },
-            { text: 'Arbitrage', link: '/advanced-strategies/arbitrage' }
+            { text: 'Overview', link: '/advanced-strategies/' }
           ]
         }
       ],
@@ -361,7 +344,7 @@ export default defineConfig({
     },
     lineNumbers: true,
     html: true,
-    config: (md) => {
+    config: (_md) => {
       // Add custom markdown plugins if needed
     }
   }

--- a/docs/insights/market-analysis/index.md
+++ b/docs/insights/market-analysis/index.md
@@ -35,6 +35,5 @@ Daily technical analysis covering:
 
 ## Market Tools
 
-- [Economic Calendar](/tools/economic-calendar)
-- [Market Screener](/tools/market-screener)
-- [Volatility Calculator](/tools/volatility-calculator)
+- [Trading Calculator](/tools/calculator)
+- [Risk Calculator](/tools/risk-calculator)

--- a/docs/insights/trading-strategies/index.md
+++ b/docs/insights/trading-strategies/index.md
@@ -63,6 +63,5 @@ Perfect for those new to contract trading:
 
 ## Popular Strategy Resources
 
-- [Strategy Backtesting Tool](/tools/backtesting)
 - [Risk Calculator](/tools/risk-calculator)
-- [Position Size Calculator](/tools/position-calculator)
+- [Position Size Calculator](/tools/calculator)

--- a/docs/resources/guides-tutorials/index.md
+++ b/docs/resources/guides-tutorials/index.md
@@ -143,17 +143,15 @@ Backtest your ideas:
 - Optimization tools
 - Forward testing
 
-## Download Resources
+## Interactive Tools
 
-### PDF Guides
-- [Complete Trading Checklist](/downloads/trading-checklist.pdf)
-- [Risk Management Workbook](/downloads/risk-management.pdf)
-- [Market Analysis Templates](/downloads/analysis-templates.pdf)
+### Online Calculators
+- [Position Size Calculator](/tools/calculator)
+- [Risk Calculator](/tools/risk-calculator)
 
-### Spreadsheet Tools
-- [Position Size Calculator](/downloads/position-calculator.xlsx)
-- [Trading Journal Template](/downloads/trading-journal.xlsx)
-- [Performance Tracker](/downloads/performance-tracker.xlsx)
+### Educational Resources
+- [Glossary of Terms](/tools/glossary)
+- [Trading FAQ](/faq/trading)
 
 ## Community Learning
 


### PR DESCRIPTION
## Summary
- Remove all broken navigation links in VitePress configuration
- Fix non-existent tool references in content files
- Replace broken download links with working alternatives
- Clean up navigation structure to only include existing pages

## Changes Made
### Navigation Fixes (config.ts)
- ❌ Removed `/insights/market-analysis/weekly`
- ❌ Removed `/insights/market-analysis/technical` 
- ❌ Removed `/insights/trading-strategies/beginner`
- ❌ Removed `/insights/trading-strategies/advanced`
- ❌ Removed `/basics/terminology`
- ❌ Removed `/basics/account-setup`
- ❌ Removed `/basics/interface`
- ❌ Removed entire "Advanced Risk Control" section
- ❌ Removed `/advanced-strategies/scalping|swing-trading|arbitrage`

### Content Link Fixes
- ❌ Removed `/tools/backtesting` 
- ❌ Removed `/tools/economic-calendar`
- ❌ Removed `/tools/market-screener`
- ❌ Removed `/tools/volatility-calculator`
- ❌ Removed all `/downloads/*.pdf` and `/downloads/*.xlsx` links
- ✅ Replaced with working `/tools/calculator` and `/tools/risk-calculator` links

### Technical
- Fixed unused parameter warning in markdown config

## Testing
All navigation links now point to existing pages. No more 404 errors! 🎉

🤖 Generated with [Claude Code](https://claude.ai/code)