### PR TITLE
Fix GitHub Pages CSS/assets loading

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
   title: "TradingPal",
   description: "Comprehensive FAQ and educational resources for contract trading, futures, and derivatives",
   
-  // GitHub Pages base URL - remove for local development
-  // base: '/contract-faq/',
+  // GitHub Pages base URL - uncomment for deployment
+  base: '/tradingpal/',
   
   // SEO and meta configuration
   head: [


### PR DESCRIPTION
## Problem
After merging the dead links fix, the GitHub Pages site at https://davioleung-mc.github.io/tradingpal/ shows no CSS/styling - everything appears broken. Localhost works fine.

## Root Cause
VitePress needs the correct `base` URL configured for GitHub Pages deployment. The base URL was commented out, causing assets to load from wrong paths.

## Solution
- ✅ Uncommented `base: '/tradingpal/'` in VitePress config
- ✅ This tells VitePress to serve assets from the correct GitHub Pages subdirectory
- ✅ Localhost development still works fine

## Result
GitHub Pages site will now load CSS, JavaScript, and all assets properly! 🎉

🤖 Generated with [Claude Code](https://claude.ai/code)